### PR TITLE
Implement lattice post‑processing workflow

### DIFF
--- a/MAAS-SFRThelper.sln
+++ b/MAAS-SFRThelper.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{3D5E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Voronoi3d", "Voronoi3d\Voronoi3d.csproj", "{84E535FB-2233-4E7A-AE69-F97B944A84F6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LatticePostProcessTests", "Tests\LatticePostProcessTests.csproj", "{5941A5A3-F51B-4C82-8CDC-F2747B230D20}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,8 +52,20 @@ Global
 		{84E535FB-2233-4E7A-AE69-F97B944A84F6}.Release|x64.ActiveCfg = Release|Any CPU
 		{84E535FB-2233-4E7A-AE69-F97B944A84F6}.Release|x64.Build.0 = Release|Any CPU
 		{84E535FB-2233-4E7A-AE69-F97B944A84F6}.Release|x86.ActiveCfg = Release|Any CPU
-		{84E535FB-2233-4E7A-AE69-F97B944A84F6}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {84E535FB-2233-4E7A-AE69-F97B944A84F6}.Release|x86.Build.0 = Release|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Debug|x64.Build.0 = Debug|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Debug|x86.Build.0 = Debug|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Release|Any CPU.Build.0 = Release|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Release|x64.ActiveCfg = Release|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Release|x64.Build.0 = Release|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Release|x86.ActiveCfg = Release|Any CPU
+                {5941A5A3-F51B-4C82-8CDC-F2747B230D20}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/MAAS-SFRThelper/App.config
+++ b/MAAS-SFRThelper/App.config
@@ -8,6 +8,10 @@
     <add key="EULAAgree" value="false"/>
     <add key="ValidForClinicalUse" value="false"/>
     <add key="ClientSettingsProvider.ServiceUri" value=""/>
+    <add key="TumourEdgeBuffer_mm" value="5"/>
+    <add key="OARBuffer_mm" value="15"/>
+    <add key="BoostShell_mm" value="2"/>
+    <add key="OuterRing_mm" value="10"/>
   </appSettings>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/MAAS-SFRThelper/ViewModels/SphereDialogViewModel.cs
+++ b/MAAS-SFRThelper/ViewModels/SphereDialogViewModel.cs
@@ -20,6 +20,7 @@ using MAAS_SFRThelper.Services;
 using System.Windows.Interop;
 using System.Windows.Media.Media3D;
 using System.Security.Policy;
+using System.Globalization;
 
 namespace MAAS_SFRThelper.ViewModels
 {
@@ -180,6 +181,41 @@ namespace MAAS_SFRThelper.ViewModels
             set { SetProperty(ref yShift, value); }
         }
 
+        private double tumourEdgeBuffer;
+        public double TumourEdgeBuffer
+        {
+            get { return tumourEdgeBuffer; }
+            set { SetProperty(ref tumourEdgeBuffer, value); }
+        }
+
+        private double oarBuffer;
+        public double OARBuffer
+        {
+            get { return oarBuffer; }
+            set { SetProperty(ref oarBuffer, value); }
+        }
+
+        private double boostShell;
+        public double BoostShell
+        {
+            get { return boostShell; }
+            set { SetProperty(ref boostShell, value); }
+        }
+
+        private double outerRing;
+        public double OuterRing
+        {
+            get { return outerRing; }
+            set { SetProperty(ref outerRing, value); }
+        }
+
+        private bool overwriteStructures;
+        public bool OverwriteStructures
+        {
+            get { return overwriteStructures; }
+            set { SetProperty(ref overwriteStructures, value); }
+        }
+
         private float radius;
         public float Radius
         {
@@ -312,6 +348,16 @@ namespace MAAS_SFRThelper.ViewModels
             LateralScalingFactor = 1.0;
             CreateLatticeCommand = new DelegateCommand(CreateLattice, CanCreateLattice);
             LSFVisibility = true;
+
+            double.TryParse(AppConfig.GetValueByKey("TumourEdgeBuffer_mm"), NumberStyles.Any, CultureInfo.InvariantCulture, out tumourEdgeBuffer);
+            if (tumourEdgeBuffer == 0) tumourEdgeBuffer = 5;
+            double.TryParse(AppConfig.GetValueByKey("OARBuffer_mm"), NumberStyles.Any, CultureInfo.InvariantCulture, out oarBuffer);
+            if (oarBuffer == 0) oarBuffer = 15;
+            double.TryParse(AppConfig.GetValueByKey("BoostShell_mm"), NumberStyles.Any, CultureInfo.InvariantCulture, out boostShell);
+            if (boostShell == 0) boostShell = 2;
+            double.TryParse(AppConfig.GetValueByKey("OuterRing_mm"), NumberStyles.Any, CultureInfo.InvariantCulture, out outerRing);
+            if (outerRing == 0) outerRing = 10;
+            OverwriteStructures = true;
 
             // Set valid spacings based on CT img z resolution
             // ValidSpacings = new List<Spacing>();
@@ -1573,6 +1619,112 @@ namespace MAAS_SFRThelper.ViewModels
 
             // Build spheres
             BuildSpheres(true);
+
+            // Post process lattice to generate boost and helper volumes
+            LatticePostProcess();
+        }
+
+        private void LatticePostProcess()
+        {
+            _esapiWorker.Run(sc =>
+            {
+                var ss = sc.StructureSet;
+                var ptv20 = ss.Structures.FirstOrDefault(s => s.Id.Equals("PTV20", StringComparison.OrdinalIgnoreCase));
+                var peaks = ss.Structures.FirstOrDefault(s => s.Id.Equals("LAT_PEAKS", StringComparison.OrdinalIgnoreCase));
+                if (ptv20 == null || peaks == null)
+                {
+                    MessageBox.Show("Required structures PTV20 or LAT_PEAKS not found.");
+                    return;
+                }
+
+                var hull = ss.AddStructure("CONTROL", "tmp_hull");
+                hull.SegmentVolume = ptv20.Margin(-tumourEdgeBuffer);
+
+                var ptvTmp = ss.AddStructure("CONTROL", "ptv6670_tmp");
+                ptvTmp.SegmentVolume = peaks.And(hull);
+
+                if (peaks.Volume > 0 && ptvTmp.Volume / peaks.Volume < 0.8)
+                {
+                    MessageBox.Show("Peaks near surface were cropped");
+                }
+
+                ss.RemoveStructure(hull);
+
+                foreach (var oar in ss.Structures.Where(o => o.DicomType == "OAR"))
+                {
+                    if (MinSurfaceDistance(ptvTmp, oar) < oarBuffer)
+                    {
+                        var oarMargin = ss.AddStructure("CONTROL", "tmp_oar");
+                        oarMargin.SegmentVolume = oar.Margin(oarBuffer);
+                        ptvTmp.SegmentVolume = ptvTmp.Sub(oarMargin);
+                        ss.RemoveStructure(oarMargin);
+                    }
+                }
+
+                if (ptvTmp.Volume == 0)
+                {
+                    MessageBox.Show("No safe peaks remain");
+                    ss.RemoveStructure(ptvTmp);
+                    return;
+                }
+
+                var ptv6670 = RenameOrOverwrite(ss, ptvTmp, "PTV_6670", "PTV");
+
+                var ptv20Opt = ss.AddStructure("CONTROL", "tmp_ptv20_opt");
+                ptv20Opt.SegmentVolume = ptv20.Sub(ptv6670.Margin(boostShell));
+                RenameOrOverwrite(ss, ptv20Opt, "PTV20_opt", "CONTROL");
+
+                var peakShell = ss.AddStructure("CONTROL", "tmp_peak_shell");
+                peakShell.SegmentVolume = ptv6670.Margin(boostShell).Sub(ptv6670);
+                RenameOrOverwrite(ss, peakShell, "Ring_PeakShell", "CONTROL");
+
+                var ptvOuter = ss.AddStructure("CONTROL", "tmp_ptv_outer");
+                ptvOuter.SegmentVolume = ptv20.Margin(outerRing).Sub(ptv20);
+                RenameOrOverwrite(ss, ptvOuter, "Ring_PTVOuter", "CONTROL");
+
+                var ptvAvoid = ss.AddStructure("CONTROL", "tmp_ptv_avoid");
+                ptvAvoid.SegmentVolume = ptv20.Sub(ptv6670);
+                RenameOrOverwrite(ss, ptvAvoid, "PTV_Avoid", "CONTROL");
+
+            });
+        }
+
+        private double MinSurfaceDistance(Structure a, Structure b)
+        {
+            double min = double.MaxValue;
+            foreach (var pa in a.MeshGeometry.Positions)
+            {
+                foreach (var pb in b.MeshGeometry.Positions)
+                {
+                    var dx = pa.X - pb.X;
+                    var dy = pa.Y - pb.Y;
+                    var dz = pa.Z - pb.Z;
+                    var dist = Math.Sqrt(dx * dx + dy * dy + dz * dz);
+                    if (dist < min) min = dist;
+                }
+            }
+            return min;
+        }
+
+        private Structure RenameOrOverwrite(StructureSet ss, Structure roi, string id, string dicomType)
+        {
+            var existing = ss.Structures.FirstOrDefault(s => s.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+            if (existing != null)
+            {
+                if (OverwriteStructures)
+                {
+                    ss.RemoveStructure(existing);
+                }
+                else
+                {
+                    return existing;
+                }
+            }
+
+            var newStruct = ss.AddStructure(dicomType, id);
+            newStruct.SegmentVolume = roi.SegmentVolume;
+            ss.RemoveStructure(roi);
+            return newStruct;
         }
     }
 }

--- a/MAAS-SFRThelper/Views/SphereDialog.xaml
+++ b/MAAS-SFRThelper/Views/SphereDialog.xaml
@@ -22,6 +22,8 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
 
         </Grid.RowDefinitions>
@@ -92,9 +94,19 @@
             <Button  Height="26"  Margin="10" HorizontalAlignment="Stretch" VerticalAlignment="Top" Content="Create" Command="{Binding CreateLatticeCommand}" Style="{x:Null}" />
             <TextBlock Foreground="red" Text="{Binding LatticeValidationText}" Visibility="{Binding LVVis, Converter={StaticResource localVisibilityConverter}}" />
         </StackPanel>
-        <ProgressBar Grid.Row="5" Margin="10" Maximum="100" Minimum="0" Value="{Binding ProgressValue}" 
+        <Label Grid.Row="5" Height="26" Margin="10" Content="Tumor Edge Buffer (mm)" />
+        <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding TumourEdgeBuffer}" Height="26" Margin="10" Width="123" />
+        <Label Grid.Row="5" Grid.Column="2" Height="26" Margin="10" Content="OAR Buffer (mm)" />
+        <TextBox Grid.Row="5" Grid.Column="3" Text="{Binding OARBuffer}" Height="26" Margin="10" Width="123" />
+
+        <Label Grid.Row="6" Height="26" Margin="10" Content="Boost Shell (mm)" />
+        <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding BoostShell}" Height="26" Margin="10" Width="123" />
+        <Label Grid.Row="6" Grid.Column="2" Height="26" Margin="10" Content="Outer Ring (mm)" />
+        <TextBox Grid.Row="6" Grid.Column="3" Text="{Binding OuterRing}" Height="26" Margin="10" Width="123" />
+        <CheckBox Grid.Row="6" Grid.ColumnSpan="4" Margin="10" Content="Overwrite existing" IsChecked="{Binding OverwriteStructures}" HorizontalAlignment="Left" />
+        <ProgressBar Grid.Row="7" Margin="10" Maximum="100" Minimum="0" Value="{Binding ProgressValue}"
                      Grid.ColumnSpan="4" Height="20"/>
-        <TextBlock Grid.Row ="6" Grid.ColumnSpan="4" Margin="10" Text="{Binding Output}">
+        <TextBlock Grid.Row ="8" Grid.ColumnSpan="4" Margin="10" Text="{Binding Output}">
 
                 </TextBlock>
         </Grid>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Features
   * example: 2 = 2x the spacing between spheres laterally, vs spacing in the head to foot direction
   * larger lateral spacing could increase peak to valley ratio in coplanar VMAT delivery
   * not currently supported with CVT3D
+* Automated post processing generates `PTV_6670` and optimisation rings from `LAT_PEAKS`
 
 Features planned
 * display volume of selected target in lower console output

--- a/Tests/LatticePostProcessTests.csproj
+++ b/Tests/LatticePostProcessTests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MAAS-SFRThelper\MAAS-SFRThelper.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/UnitTest1.cs
+++ b/Tests/UnitTest1.cs
@@ -1,0 +1,14 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LatticePostProcessTests
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void DummyTest()
+        {
+            Assert.IsTrue(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable margin parameters to `App.config`
- expose new parameters and overwrite option in Sphere dialog UI
- implement `LatticePostProcess` logic with helper methods
- update README with new automation feature
- include test project skeleton

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

## Summary by Sourcery

Implement configurable lattice post-processing workflow to generate boost and optimisation structures, expose new parameters in the UI, update documentation, and add a test project skeleton

New Features:
- Expose configurable lattice post-processing parameters (tumour edge buffer, OAR buffer, boost shell, outer ring) and overwrite option in the Sphere dialog UI
- Implement automated lattice post-processing workflow to generate boost and optimisation structures (PTV_6670, PTV20_opt, Ring_PeakShell, Ring_PTVOuter, PTV_Avoid) from LAT_PEAKS
- Add a skeleton unit test project for lattice post-processing

Documentation:
- Update README to document the new automated post-processing feature

Tests:
- Introduce a dummy unit test to establish the testing infrastructure