### PR TITLE
Modify sphere cleaning

### DIFF
--- a/MAAS-SFRThelper/Views/SphereDialog.xaml
+++ b/MAAS-SFRThelper/Views/SphereDialog.xaml
@@ -25,6 +25,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
 
         </Grid.RowDefinitions>
@@ -105,12 +106,13 @@
         <Label Grid.Row="6" Grid.Column="2" Height="26" Margin="10" Content="Outer Ring (mm)" />
         <TextBox Grid.Row="6" Grid.Column="3" Text="{Binding OuterRing}" Height="26" Margin="10" Width="123" />
         <CheckBox Grid.Row="6" Grid.ColumnSpan="4" Margin="10" Content="Overwrite existing" IsChecked="{Binding OverwriteStructures}" HorizontalAlignment="Left" />
+        <CheckBox Grid.Row="7" Grid.ColumnSpan="4" Margin="10" Content="Remove peaks near shell" IsChecked="{Binding RemoveWholePeaks}" HorizontalAlignment="Left" />
 
-        <Button Grid.Row="7" Grid.ColumnSpan="4" Height="26" Margin="10" Content="Generate Helpers" Command="{Binding RunPostProcessCommand}" />
+        <Button Grid.Row="8" Grid.ColumnSpan="4" Height="26" Margin="10" Content="Generate Helpers" Command="{Binding RunPostProcessCommand}" />
 
-        <ProgressBar Grid.Row="8" Margin="10" Maximum="100" Minimum="0" Value="{Binding ProgressValue}"
+        <ProgressBar Grid.Row="9" Margin="10" Maximum="100" Minimum="0" Value="{Binding ProgressValue}"
                      Grid.ColumnSpan="4" Height="20"/>
-        <TextBlock Grid.Row ="9" Grid.ColumnSpan="4" Margin="10" Text="{Binding Output}">
+        <TextBlock Grid.Row ="10" Grid.ColumnSpan="4" Margin="10" Text="{Binding Output}">
 
                 </TextBlock>
         </Grid>


### PR DESCRIPTION
## Summary
- keep original target structure when running sphere generation
- option to remove entire peaks when they intersect the inner shell
- expose checkbox for removing peaks in the UI

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

## Summary by Sourcery

Add an option to remove fully enclosed spheres during sphere generation and preserve original target structures when renaming.

New Features:
- Expose a RemoveWholePeaks checkbox in the UI to toggle removal of entire peaks within the inner shell.

Enhancements:
- Introduce a removeSource flag in RenameOrOverwrite to keep the original structure when renaming.
- Extend lattice post-processing to conditionally merge or remove spheres based on the RemoveWholePeaks setting.